### PR TITLE
Add forwarding for `/password_reset_request path`

### DIFF
--- a/src/main/java/uk/ac/ebi/biostudies/submissiontool/controllers/PageController.java
+++ b/src/main/java/uk/ac/ebi/biostudies/submissiontool/controllers/PageController.java
@@ -12,6 +12,7 @@ public class PageController {
             "/activation/**",
             "/activate/**",
             "/password_reset/**",
+            "/password_reset_request",
             "/drafts/**",
             "/edit/**",
             "/files/**",


### PR DESCRIPTION
Add forwarding for `/password_reset_request path` in Spring controller to support Vue Router history mode

- Included explicit mapping of /password_reset_request in PageController.
- Ensures direct URL access to the password reset request page correctly forwards to index.html.
- Fixes issue where direct navigation to /password_reset_request resulted in 404 or blank page.