### PR TITLE
Adjust CI configuration to handle all VITE configuration as a file variable

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,6 +12,11 @@ build:
     paths:
       - target/*.jar
   script:
+    # Copy VITE_CONFIG file variable into frontend/.env
+    - cp "$VITE_CONFIG" frontend/.env
+    - echo "Using VITE config:"
+    - cat frontend/.env
+
     - mvn clean package
 
 .deploy-template: &deploy-template


### PR DESCRIPTION
This allows to have less variables in the CI configuration, and the correct injection of the values to the .env