### PR TITLE
Fix missing properties in general tables

### DIFF
--- a/frontend/src/components/Section.vue
+++ b/frontend/src/components/Section.vue
@@ -569,10 +569,10 @@ defineExpose({ errors, thisSection });
                 :rows="subsection"
                 :depth="props.depth + 1"
                 :sectionType="
-                  subSectionTypeMap.get(subsection?.name?.toLowerCase())
+                  subSectionTypeMap.get(subsection[0]?.type?.toLowerCase())
                 "
                 :sectionSubType="
-                  subSectionTypeMap.get(subsection?.name?.toLowerCase())?.name
+                  subSectionTypeMap.get(subsection[0]?.type?.toLowerCase())?.name
                 "
                 :parent="section"
                 @rowsReordered="(e) => rowsReordered(e, subsection)"


### PR DESCRIPTION
- `SectionTable` for general tables was not receiving correctly the properties data. It worked before fixing another bug, so this change is necessary for it to work correctly after that fix